### PR TITLE
WL-4007 . Adding exception handling .

### DIFF
--- a/impl/src/java/org/sakaiproject/poll/service/impl/PollVoteManagerImpl.java
+++ b/impl/src/java/org/sakaiproject/poll/service/impl/PollVoteManagerImpl.java
@@ -137,11 +137,16 @@ public class PollVoteManagerImpl implements PollVoteManager {
 		Search search = new Search();
 		search.addRestriction(new Restriction("userId",userID));
 		search.addRestriction(new Restriction("pollId",pollid));
-		List<Vote> votes = dao.findBySearch(Vote.class, search);		
-		if (votes.size() > 0)
-			return true;
-		else
+		try {
+			List<Vote> votes = dao.findBySearch(Vote.class, search);
+			if (votes.size() > 0)
+				return true;
+			else
+				return false;
+		}catch(Exception e) {
+			log.debug("Poll has null values on search criteria"+e.getMessage());
 			return false;
+		}
 	}
 
 	public boolean userHasVoted(Long pollId) {


### PR DESCRIPTION
UserId being added to the restrictions in search criteria is always null for public poll(user not logged in)
The search always throws exception with the message that restriction property andvalue and value cannot be null.
